### PR TITLE
Add notes, manual uploads, and item deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A ready‑to‑run Flask web app to track damaged furniture across vendors, inge
 - **Dashboard**: filter/search by vendor, status, PO/SKU, date
 - **Manual entry** of damaged items
 - **Credits**: create credits (issued), apply credits to one or more items, see remaining balance
-- **Attachments**: store Google Drive links (or plain URLs) for photos
+- **Attachments**: store Google Drive links (or plain URLs) for photos and upload files manually
+- **Notes**: add internal notes/updates on each item
+- **Delete tickets**: admins can remove items when resolved or entered by mistake
 - **Email ingestion via Zapier**:
   - Gmail (Account A + Account B) → (optional) Upload attachments to Google Drive → **POST to `/zap/webhook`**
   - Flexible parser: finds `PO`, `SKU`, `Credit $123.45`, and basic intent in subject/body
@@ -125,7 +127,7 @@ Tables are auto‑created on startup with SQLAlchemy.
 
 - **Dashboard:** filter by Status/Vendor, search PO/SKU/Title
 - **New Item:** click “New Item” to enter manually (no email required)
-- **Item Detail:** add notes, change status, add attachment links
+- **Item Detail:** add notes, change status, upload attachments, and delete tickets
 - **Credits:**
   - “New Credit” creates a **credit pool** with a **remaining balance**
   - Apply all or part of a credit to one or more items

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -4,12 +4,19 @@
   <div class="md:col-span-2 bg-white card p-4">
     <div class="flex justify-between items-center">
       <h2 class="text-lg font-semibold">Item #{{ item.id }} — {{ item.title }}</h2>
-      <form method="post" action="{{ url_for('update_item_status', item_id=item.id) }}" class="flex gap-2 items-center">
-        <select name="status" class="border rounded-xl px-3 py-1.5">
-          {% for s in statuses %}<option value="{{ s }}" {% if item.status==s %}selected{% endif %}>{{ s }}</option>{% endfor %}
-        </select>
-        <button class="px-3 py-1.5 rounded-xl bg-slate-900 text-white">Save</button>
-      </form>
+      <div class="flex gap-2 items-center">
+        <form method="post" action="{{ url_for('update_item_status', item_id=item.id) }}" class="flex gap-2 items-center">
+          <select name="status" class="border rounded-xl px-3 py-1.5">
+            {% for s in statuses %}<option value="{{ s }}" {% if item.status==s %}selected{% endif %}>{{ s }}</option>{% endfor %}
+          </select>
+          <button class="px-3 py-1.5 rounded-xl bg-slate-900 text-white">Save</button>
+        </form>
+        {% if role == 'admin' %}
+        <form method="post" action="{{ url_for('delete_item', item_id=item.id) }}" onsubmit="return confirm('Delete this item?');">
+          <button class="px-3 py-1.5 rounded-xl bg-rose-600 text-white">Delete</button>
+        </form>
+        {% endif %}
+      </div>
     </div>
     <div class="text-sm text-slate-600 mt-1">Vendor: <b>{{ item.vendor or '-' }}</b> • PO: <b>{{ item.po_number or '-' }}</b> • SKU: <b>{{ item.sku or '-' }}</b></div>
     <div class="mt-2">
@@ -33,6 +40,10 @@
         <input name="url" placeholder="Paste link (Drive, photo, etc.)" class="border rounded-xl px-3 py-2 flex-1">
         <button class="px-3 py-2 rounded-xl bg-emerald-600 text-white">Add</button>
       </form>
+      <form method="post" action="{{ url_for('upload_file', item_id=item.id) }}" enctype="multipart/form-data" class="mt-2 flex gap-2 items-center">
+        <input type="file" name="file" accept="image/*,.pdf" class="border rounded-xl px-3 py-2" required />
+        <button class="px-3 py-2 rounded-xl bg-emerald-600 text-white">Upload</button>
+      </form>
 
       <div class="mt-6">
         <h3 class="font-semibold">Upload Photo/PDF to Drive (via Zap)</h3>
@@ -41,6 +52,23 @@
           <button class="px-3 py-2 rounded-xl bg-purple-600 text-white">Upload to Drive via Zap</button>
         </form>
         <p class="text-xs text-slate-500 mt-1">Sends the file to your Zap (OUTGOING_WEBHOOK_URL). The Zap uploads to Drive and calls back to <code>/zap/attach</code> to attach.</p>
+      </div>
+
+      <div class="mt-6">
+        <h3 class="font-semibold mb-2">Notes</h3>
+        {% if item.notes %}
+          <ul class="list-disc pl-6 text-sm">
+            {% for n in item.notes %}
+              <li>{{ n.content }} <span class="text-slate-500">({{ n.created_at.strftime('%Y-%m-%d %H:%M') }})</span></li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <div class="text-sm text-slate-500">No notes yet.</div>
+        {% endif %}
+        <form method="post" action="{{ url_for('add_note', item_id=item.id) }}" class="mt-2 flex gap-2">
+          <input name="content" placeholder="Add note" class="border rounded-xl px-3 py-2 flex-1">
+          <button class="px-3 py-2 rounded-xl bg-slate-900 text-white">Add</button>
+        </form>
       </div>
 
       <div class="mt-3 flex gap-2">


### PR DESCRIPTION
## Summary
- Support local file uploads and save as attachments.
- Add per-item note model and form to log updates.
- Allow administrators to delete tickets.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0c09de9e883318c13525ae36426b2